### PR TITLE
ci/adr enforcement

### DIFF
--- a/.github/ISSUE_TEMPLATE/adr.md
+++ b/.github/ISSUE_TEMPLATE/adr.md
@@ -1,0 +1,24 @@
+name: ADR Proposal
+about: Propose an Architectural Decision Record
+labels: adr
+body:
+  - type: textarea
+    attributes:
+      label: Context
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Decision
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Consequences
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Security & Privacy Considerations
+      description: Reference controls where applicable (e.g., NIST 800-53)
+

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,17 @@
+name: Chore / Maintenance
+about: Repo hygiene, CI, docs, or non-feature work
+labels: chore
+body:
+  - type: textarea
+    attributes:
+      label: Task
+      description: What needs to be done?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Acceptance Criteria
+      value: |
+        - [ ] ...
+        - [ ] ...
+

--- a/.github/ISSUE_TEMPLATE/governance.md
+++ b/.github/ISSUE_TEMPLATE/governance.md
@@ -1,0 +1,16 @@
+name: Governance / ARB
+about: Charter updates, ARB agenda items, cadences
+labels: governance
+body:
+  - type: textarea
+    attributes:
+      label: Proposal
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Acceptance Criteria
+      value: |
+        - [ ] Decision captured in ADR or governance doc
+        - [ ] Agenda updated / minutes recorded
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,13 @@ jobs:
       - name: Install mkdocs
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs mkdocs-material
+          pip install mkdocs mkdocs-material mkdocs-macros-plugin
+      - name: Install graphviz
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+      - name: Generate decision registry and graph
+        run: |
+          python scripts/generate_decision_registry.py
+          dot -Tpng docs/adr/graph.dot -o docs/adr/graph.png
       - name: Build
         run: |
           mkdocs build

--- a/.github/workflows/traceability.yml
+++ b/.github/workflows/traceability.yml
@@ -1,0 +1,20 @@
+name: traceability
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  validate-traceability:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Validate traceability
+        run: |
+          python scripts/validate_traceability.py
+

--- a/docs/governance/arb-charter.md
+++ b/docs/governance/arb-charter.md
@@ -1,0 +1,22 @@
+# Architecture Review Board (ARB) Charter
+
+Purpose
+
+- Ensure cross-cutting decisions align with strategy and standards.
+- Improve org decision-making capability; enable team autonomy.
+
+Scope
+
+- Reviews Tier-1/Tier-2 ADRs and decisions with org-wide impact.
+- Team-level (Tier-3) ADRs generally self-serve unless flagged.
+
+Cadence & Process
+
+- Weekly readout (30 min) using decision graph portfolio.
+- Readiness: ADR proposal issue + draft ADR with Metadata & Security.
+- Outcomes: Accept/Request changes/Defer with owner & follow-up.
+
+Membership
+
+- Platform, Security, Product, Domain leads (small and cross-functional).
+

--- a/docs/platform-slos.md
+++ b/docs/platform-slos.md
@@ -1,0 +1,14 @@
+# Platform SLOs (Developer-Centric)
+
+These SLOs measure the internal developer experience provided by the framework and its tooling. Targets are initial and subject to refinement.
+
+- SLO-PR-FEEDBACK-P95-15M: 95% of pull requests receive CI feedback (tests + lint) within 15 minutes.
+- SLO-SAVE-SUCCESS-99_9: Monthly success rate for `chatlog save` ≥ 99.9%.
+- SLO-SAVE-LATENCY-P95-200MS: 95th percentile latency from save invocation to index update < 200ms (local run).
+- SLO-DOCS-BUILD-GREEN: Docs build passes on main 100% of the time; link-check has ≥ 99% pass rate.
+- SLO-ONBOARD-15M: Time to install and run first successful `chatlog save` from a fresh clone ≤ 15 minutes (measured periodically).
+
+Notes
+
+- Measurement sources may be a combination of CI timings, local benchmarks, and periodic surveys.
+- As capabilities evolve (centralized storage, telemetry), these SLOs should be refined and made more objective.

--- a/docs/traceability.json
+++ b/docs/traceability.json
@@ -1,0 +1,17 @@
+{
+  "initiatives": [
+    {
+      "id": "INIT-001",
+      "title": "Crash-safe AI chat context capture",
+      "okrs": ["OKR-DEV-01"],
+      "adrs": ["0003", "0006", "0007", "0008"],
+      "epics": [
+        "https://example.com/tracker/EPIC-100",
+        "https://example.com/tracker/EPIC-101"
+      ],
+      "controls": ["NIST-800-53:SC-28", "NIST-800-53:AU-2"],
+      "slos": ["SLO-PR-FEEDBACK-P95-15M", "SLO-SAVE-SUCCESS-99_9"]
+    }
+  ]
+}
+

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -1,0 +1,17 @@
+# Golden Thread Traceability
+
+This document describes how we link strategy to execution using a simple, machine‑readable map:
+
+- Vision → OKRs → ADRs → Epics → Controls → SLOs
+
+Artifacts
+
+- `docs/traceability.json`: canonical, machine‑readable mapping.
+- Validator: `scripts/validate_traceability.py` checks referenced ADR IDs exist.
+- CI: `traceability` workflow validates on PRs and pushes.
+
+Usage
+
+- Add a new initiative to `docs/traceability.json` with IDs for OKRs, ADRs, epics (ticket URLs), control IDs (e.g., NIST 800‑53), and SLO IDs.
+- The validator ensures that ADR IDs exist in `docs/adr/`.
+

--- a/meetings/templates/arb-readout.md
+++ b/meetings/templates/arb-readout.md
@@ -1,0 +1,6 @@
+# ARB Readout Agenda
+
+- Decision Registry portfolio (graph)
+- ADRs requiring ARB review (cross-cutting)
+- Technical debt hotspots (superseded clusters)
+- Action items and owners

--- a/meetings/templates/backlog-refinement.md
+++ b/meetings/templates/backlog-refinement.md
@@ -1,0 +1,10 @@
+# Backlog Refinement Agenda
+
+- Review new issues (triage/labels/milestones)
+- Clarify acceptance criteria
+- Prioritize (P1/P2/P3)
+- Assign readiness (move to Ready when clear)
+
+Notes:
+- Link: Decision Registry & Graph
+- Link: Traceability view

--- a/meetings/templates/sprint-planning.md
+++ b/meetings/templates/sprint-planning.md
@@ -1,0 +1,6 @@
+# Sprint Planning Agenda
+
+- Review Ready items and capacity
+- Select Sprint Backlog
+- Confirm Definition of Done (checks/validators)
+- Assign owners; set milestones

--- a/scripts/validate_traceability.py
+++ b/scripts/validate_traceability.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR_DIR = ROOT / "docs" / "adr"
+TRACE = ROOT / "docs" / "traceability.json"
+
+TITLE_RE = re.compile(r"^#\s+(\d+)\.\s+.+$")
+
+
+def collect_adr_ids() -> set[str]:
+    ids: set[str] = set()
+    for p in ADR_DIR.glob("*.md"):
+        try:
+            first = p.read_text(encoding="utf-8").splitlines()[0].strip()
+        except Exception:
+            continue
+        m = TITLE_RE.match(first)
+        if m:
+            ids.add(m.group(1))
+    return ids
+
+
+def validate_traceability() -> list[str]:
+    problems: list[str] = []
+    if not TRACE.exists():
+        return [f"missing {TRACE.relative_to(ROOT)}"]
+    try:
+        data = json.loads(TRACE.read_text(encoding="utf-8"))
+    except Exception as e:
+        return [f"invalid JSON: {e}"]
+
+    adrs_present = collect_adr_ids()
+    inits = data.get("initiatives", [])
+    if not isinstance(inits, list):
+        problems.append("initiatives must be a list")
+        return problems
+
+    for i, init in enumerate(inits, 1):
+        if not isinstance(init, dict):
+            problems.append(f"initiative[{i}] is not an object")
+            continue
+        adr_list = init.get("adrs", [])
+        for adr in adr_list:
+            if adr not in adrs_present:
+                problems.append(f"initiative {init.get('id','?')}: ADR {adr} not found in docs/adr/")
+    return problems
+
+
+def main() -> int:
+    probs = validate_traceability()
+    if probs:
+        print("Traceability validation failed:")
+        for p in probs:
+            print(f"- {p}")
+        return 1
+    print("Traceability validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
- **feat(traceability): add traceability scaffold, validator, and CI; docs: add developer-centric platform SLOs**
- **chore(pm): add issue templates, meeting agendas, and ARB charter**
- **docs(ci): publish decision registry and graph via docs build (mkdocs + graphviz)**
- **ci(adr): enforce Metadata and Security sections for new ADRs (via ADR_ENFORCE_DATE)**
