### PR TITLE
chore(dev): add doctor-commits helper and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,3 +70,11 @@ ruff check .                  # lint
 ruff format .                 # format
 pytest -q
 ```
+
+
+## Commit Messages & Local Checks
+
+- Conventional Commits enforced locally and in CI.
+- Install hooks: `make hooks` (includes commit-msg).
+- Preflight: `make doctor-commits` (uses Commitizen or commitlint).
+- Fix history: `git rebase -i origin/main` (reword), or squash and `git push --force-with-lease`.

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,7 @@ e2e: ## Run local end-to-end validation script
 
 smoke-staging: ## Rsync real history to a staging dir and run a safe smoke test
 	bash scripts/smoke_staging.sh
+
+
+doctor-commits: ## Check commit messages locally (cz or commitlint)
+	bash scripts/doctor_commits.sh

--- a/README.md
+++ b/README.md
@@ -105,3 +105,11 @@ Clean Up History (example)
   - `git rebase -i origin/main`
   - Mark small follow-ups as `fixup` or `squash` under the main commit.
   - Force-push your branch if needed: `git push -f`.
+
+
+## Commit Messages & Local Checks
+
+- Conventional Commits enforced locally and in CI.
+- Install hooks: `make hooks` (includes commit-msg).
+- Preflight: `make doctor-commits` (uses Commitizen or commitlint).
+- Fix history: `git rebase -i origin/main` (reword), or squash and `git push --force-with-lease`.

--- a/scripts/doctor_commits.sh
+++ b/scripts/doctor_commits.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base=${1:-}
+if [[ -z "${base}" ]]; then
+  base=$(git merge-base HEAD origin/main 2>/dev/null || echo origin/main)
+fi
+
+echo "Commit range: ${base}..HEAD"
+status=0
+if command -v cz >/dev/null 2>&1; then
+  echo "Using Commitizen to check history..."
+  if ! cz check --rev-range "${base}..HEAD"; then status=1; fi
+elif command -v npx >/dev/null 2>&1; then
+  echo "Using commitlint to check history..."
+  if ! npx --yes commitlint --from "${base}" --to HEAD; then status=1; fi
+else
+  echo "No checker found. Install one of:\n  - uv pip install -e .[dev]   # provides commitizen\n  - npm i -D @commitlint/cli @commitlint/config-conventional" >&2
+  exit 2
+fi
+
+if [[ $status -ne 0 ]]; then
+  cat <<'EOF'
+Not compliant. Options to fix:
+- Interactive rebase:   git rebase -i origin/main   # mark commits as 'reword'
+- Squash to one commit: git reset --soft origin/main && git commit -m "type(scope): subject" -m "body..." && git push --force-with-lease
+EOF
+else
+  echo "Commit messages OK."
+fi
+exit $status


### PR DESCRIPTION
## Summary
Add a local developer helper to validate Conventional Commit messages before pushing.

## Motivation
Prevent CI failures in lint-commits by surfacing errors locally. Complements pre-commit commit-msg hook.

## Changes
- Add `scripts/doctor_commits.sh` (uses `cz check` or `commitlint` if available)
- Add `make doctor-commits` target
- Update docs with quick workflow

## Testing
- Run `make doctor-commits` on branches with good/bad messages; verify pass/fail and guidance.

## Checklist
- [x] Conventional Commit PR title
- [x] Small, atomic diff
- [x] CI green
- [x] No secrets or personal configs added