### PR TITLE
docs(governance): add solo-operator self-review protocol; update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,3 +22,14 @@ Why is this change needed? Link issues if applicable.
 - [ ] Small, atomic diff; unrelated changes split out
 - [ ] CI green (commitlint + PR title)
 - [ ] No secrets or personal configs added
+
+## Self-Review Checklist (Solo Operator)
+
+*As the sole contributor, I am acting as my own peer reviewer. I confirm I have completed the following before approving this PR:*
+
+- [ ] **Cooling-Off Period:** Took a 30+ minute break between writing and reviewing.
+- [ ] **Line-by-Line Review:** Re-read the entire diff.
+- [ ] **Local Validation:** Ran local checks (`make doctor-commits`, `make validate` or equivalent) and they pass.
+- [ ] **ADR Compliance:** Reviewed relevant ADRs or added/updated one if introducing a decision.
+- [ ] **Threat Model Consideration:** Considered security implications.
+- [ ] **Clarity for Future Me:** Title, description, and comments capture the “why” clearly.

--- a/README.md
+++ b/README.md
@@ -109,3 +109,7 @@ Clean Up History (example)
 ## PR Dependency Ordering
 
 See docs/ops/pr-ordering.md for how dependency mapping works and local triage commands.
+
+## Governance
+
+- Solo operator protocol: see docs/ops/solo-operator-governance.md

--- a/docs/ops/solo-operator-governance.md
+++ b/docs/ops/solo-operator-governance.md
@@ -1,0 +1,10 @@
+# Solo Operator Governance Model
+
+When a non-author reviewer is not available, we adapt the framework to preserve deliberate reviews:
+
+- **CI as Peer Reviewer:** No PR merges unless all required checks are green.
+- **Self-Approval Protocol:** Author self-approves only after completing the Self-Review Checklist in the PR.
+- **CODEOWNERS:** Critical paths auto-assign the platform-team (currently @paulkiley) to ensure heightened scrutiny.
+- **Break-Glass:** Admin merges permitted only for time-sensitive critical fixes when designated approvers are unavailable; ARB review within 1 business day.
+
+See the PR template for the mandatory checklist.


### PR DESCRIPTION
## Summary
Adopt a Solo Operator governance protocol: update PR template with a mandatory self-review checklist and add governance doc.

## Motivation
Enable disciplined, deliberate reviews when a non-author approver is not available while preserving core principles.

## Changes
- Update `.github/pull_request_template.md` to include Self-Review Checklist
- Add `docs/ops/solo-operator-governance.md`
- Link from README

## Checklist
- [x] Conventional Commit title
- [x] Small, atomic diff
- [x] CI green expected
- [x] No secrets added